### PR TITLE
Update to use roadrunner 0.1.1 and hyper 0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["yzhu <Yanhao.Zhu@am.sony.com>"]
 
 [dependencies]
-roadrunner = { git="https://github.com/luanzhu/roadrunner", branch="master" }
-hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
+roadrunner = "0.1.1"
+hyper = "0.11"
 serde="1.0"
 serde_json = "1.0"
 serde_derive="1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate hyper;
 
 use std::convert::From;
 
-use hyper::status::StatusCode;
+use hyper::StatusCode;
 use tokio_core::reactor::Core;
 use roadrunner::{RestClient, RestClientMethods};
 
@@ -143,7 +143,7 @@ impl<'a> OAuthClient<'a> {
                             .execute_on(core)
                             .map_err(|e| Error::RestClientError(e))
                             .and_then(|response| {
-                                if *response.status() == hyper::status::StatusCode::Ok {
+                                if *response.status() == hyper::StatusCode::Ok {
                                     response.content()
                                         .as_typed::<Token>()
                                         .map_err(|e| Error::RestClientError(e))


### PR DESCRIPTION
# Purpose
This PR is to update to use roadrunner 0.1.1 from crates.io with published hyper 0.11.


- 